### PR TITLE
Remove redefinition of behaviors in app-header

### DIFF
--- a/app-header/app-header.html
+++ b/app-header/app-header.html
@@ -220,10 +220,6 @@ Mixin | Description | Default
         }
       },
 
-      behaviors: [
-        Polymer.AppScrollEffectsBehavior
-      ],
-
       observers: [
         '_condensesChanged(condenses, isAttached)'
       ],


### PR DESCRIPTION
Safari 7/8 fails when the same property is defined in multiple places in an object. This fixes that for app-header.