### PR TITLE
Set transform-origin !important in Pesto

### DIFF
--- a/templates/pesto/src/recipe-list.html
+++ b/templates/pesto/src/recipe-list.html
@@ -63,7 +63,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       background-repeat: no-repeat;
       background-position: center center;
       background-size: 240px;
-      transform-origin: center top;
+      transform-origin: center top !important;
 
       /* The difference in font size is used to calculate the scale of the title in the transition. */
       font-size: 32px;


### PR DESCRIPTION
The fix in #63 took precedence over the header transform-origin style in Pesto.