### PR TITLE
Make entire app-drawer have fixed positioning

### DIFF
--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -52,6 +52,11 @@ Custom property                  | Description                            | Defa
   <style>
 
     :host {
+      position: fixed;
+      top: -120px;
+      left: 0;
+      right: 0;
+      bottom: -120px;
       visibility: hidden;
       transition: visibility 0.2s ease;
     }
@@ -61,9 +66,9 @@ Custom property                  | Description                            | Defa
     }
 
     #contentContainer {
-      position: fixed;
-      top: -120px;
-      bottom: -120px;
+      position: absolute;
+      top: 0;
+      bottom: 0;
       left: 0;
       width: 256px;
       background-color: #FFF;
@@ -108,11 +113,11 @@ Custom property                  | Description                            | Defa
     }
 
     #scrim {
-      position: fixed;
-      top: -120px;
+      position: absolute;
+      top: 0;
+      bottom: 0;
       left: 0;
       right: 0;
-      bottom: -120px;
       background: var(--app-drawer-scrim-background, rgba(0, 0, 0, 0.5));
       opacity: 0;
       transition: opacity 0.2s ease;
@@ -335,7 +340,7 @@ Custom property                  | Description                            | Defa
         var timeLowerBound = Date.now() - 100;
         var trackEvent;
         var min = 0;
-        var max = this._trackEvents.length - 1;        
+        var max = this._trackEvents.length - 1;
 
         while (min <= max) {
           // Floor of average of min and max.


### PR DESCRIPTION
This allows users to set `z-index` on the `<app-drawer>` element instead of having to set it on both its scrim and content.