### PR TITLE
remove scrim tap debouncer

### DIFF
--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -260,14 +260,9 @@ Custom property                  | Description                            | Defa
       },
 
       _scrimTapHandler: function() {
-        if (this.persistent) {
-          return;
-        }
-
-        // This debouncer is needed because of Polymer/polymer#3405.
-        this.debounce('_scrimTapHandler', function() {
+        if (!this.persistent) {
           this.opened = false;
-        }, 1);
+        }
       },
 
       _track: function(event) {
@@ -313,9 +308,6 @@ Custom property                  | Description                            | Defa
       },
 
       _trackEnd: function(event) {
-        // Track handler takes precedence over scrim tap handler. See Polymer/polymer#3405.
-        this.cancelDebouncer('_scrimTapHandler');
-
         // Calculate the velocity.
         this._velocity = this._calculateVelocity(event);
 

--- a/app-drawer/test/app-drawer.html
+++ b/app-drawer/test/app-drawer.html
@@ -141,18 +141,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isTrue(ev.defaultPrevented);
       });
 
-      test('track events block scrim tap', function(done) {
-        drawer.opened = true;
-        drawer.fire('track', { state: 'start' });
-        drawer.fire('tap', null /* detail */, { node: scrim });
-        drawer.fire('track', { state: 'end', dx: 0, ddx: 0 });
-
-        window.setTimeout(function() {
-          assert.isTrue(drawer.opened);
-          done();
-        }, 1);
-      });
-
       test('styles reset after swiping', function() {
         drawer.fire('track', { state: 'start' });
 


### PR DESCRIPTION
This was fixed by Polymer v1.3.0 and is no longer needed