### PR TITLE
Fix drawer calculate velocity method

### DIFF
--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -382,7 +382,7 @@ Custom property                  | Description                            | Defa
 
       _calculateVelocity: function(event) {
         // Find the oldest track event that is within 100ms of track end using binary search.
-        var timeLowerBound = Date.now() - 100;
+        var timeLowerBound = event.timeStamp - 100;
         var trackEvent;
         var min = 0;
         var max = this._trackEvents.length - 1;


### PR DESCRIPTION
Needed for Chrome 49 - see https://developers.google.com/web/updates/2016/01/high-res-timestamps?hl=en

Should probably be added in IOWA ASAP, so probably should do a release after merging (if there no other breaking changes on master)

cc @frankie @blasten 