### PR TITLE
Remove last focused element on drawer close; focus drawer if tabindex is set

### DIFF
--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -595,8 +595,10 @@ Custom property                  | Description                            | Defa
         }
 
         // Focus on app-drawer if it has non-zero tabindex. Otherwise, focus the first focusable
-        // element in the drawer, if it exists.
-        if (this.tabIndex !== -1) {
+        // element in the drawer, if it exists. Use the tabindex attribute since the this.tabIndex
+        // property in IE/Edge returns 0 (instead of -1) when the attribute is not set.
+        var tabindex = this.getAttribute('tabindex');
+        if (tabindex && parseInt(tabindex, 10) > -1) {
           this.focus();
         } else if (this._firstTabStop) {
           this._firstTabStop.focus();

--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -244,8 +244,6 @@ Custom property                  | Description                            | Defa
 
       _boundEscKeydownHandler: null,
 
-      _lastFocusedElement: null,
-
       _firstTabStop: null,
 
       _lastTabStop: null,
@@ -552,12 +550,11 @@ Custom property                  | Description                            | Defa
 
         if (oldState !== this._drawerState) {
           if (this._drawerState === this._DRAWER_STATE.OPENED) {
+            this._setKeyboardFocusTrap();
             document.addEventListener('keydown', this._boundEscKeydownHandler);
-            this._addKeyboardFocusTrap();
             document.body.style.overflow = 'hidden';
           } else {
             document.removeEventListener('keydown', this._boundEscKeydownHandler);
-            this._removeKeyboardFocusTrap();
             document.body.style.overflow = '';
           }
 
@@ -568,12 +565,10 @@ Custom property                  | Description                            | Defa
         }
       },
 
-      _addKeyboardFocusTrap: function() {
+      _setKeyboardFocusTrap: function() {
         if (this.noFocusTrap) {
           return;
         }
-
-        this._lastFocusedElement = this._getDeepActiveElement();
 
         // NOTE: Unless we use /deep/ (which we shouldn't since it's deprecated), this will
         // not select focusable elements inside shadow roots.
@@ -593,17 +588,18 @@ Custom property                  | Description                            | Defa
         if (focusableElements.length > 0) {
           this._firstTabStop = focusableElements[0];
           this._lastTabStop = focusableElements[focusableElements.length - 1];
-          this._firstTabStop.focus();
         } else {
           // Reset saved tab stops when there are no focusable elements in the drawer.
           this._firstTabStop = null;
           this._lastTabStop = null;
         }
-      },
 
-      _removeKeyboardFocusTrap: function() {
-        if (!this.noFocusTrap && this._lastFocusedElement) {
-          this._lastFocusedElement.focus();
+        // Focus on app-drawer if it has non-zero tabindex. Otherwise, focus the first focusable
+        // element in the drawer, if it exists.
+        if (this.tabIndex !== -1) {
+          this.focus();
+        } else if (this._firstTabStop) {
+          this._firstTabStop.focus();
         }
       },
 
@@ -626,17 +622,6 @@ Custom property                  | Description                            | Defa
             }
           }
         }
-      },
-
-      _getDeepActiveElement: function() {
-        // document.activeElement can be null
-        // https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
-        // In case of null, default it to document.body.
-        var active = document.activeElement || document.body;
-        while (active.root && Polymer.dom(active.root).activeElement) {
-          active = Polymer.dom(active.root).activeElement;
-        }
-        return active;
       },
 
       _MIN_FLING_THRESHOLD: 0.2,

--- a/app-drawer/demo/demo2.html
+++ b/app-drawer/demo/demo2.html
@@ -19,7 +19,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../../../font-roboto/roboto.html">
-  <link rel="import" href="../../../paper-styles/paper-styles.html">
   <link rel="import" href="../../../iron-icons/iron-icons.html">
   <link rel="import" href="../../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../../../paper-item/paper-icon-item.html">

--- a/app-drawer/test/app-drawer.html
+++ b/app-drawer/test/app-drawer.html
@@ -47,7 +47,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <dom-module id="focus-drawer">
     <template>
-      <button>Button</button>
       <app-drawer>
         <input type="text">
         <div tabindex="0">Div</div>
@@ -604,14 +603,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('focus trap', function(done) {
         var focusDrawer = fixture('focusDrawer');
         var root = Polymer.dom(focusDrawer.root);
-        var button = root.querySelector('button');
         var drawer = root.querySelector('app-drawer');
         var input = Polymer.dom(drawer).querySelector('input');
         var div = Polymer.dom(drawer).querySelector('div[tabindex]');
-        var buttonFocusSpy = sinon.spy(button, 'focus');
         var inputFocusSpy = sinon.spy(input, 'focus');
         var divFocusSpy = sinon.spy(div, 'focus');
-        button.focus();
         drawer.opened = true;
 
         window.setTimeout(function() {
@@ -637,26 +633,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           assert.isTrue(inputFocusSpy.called);
           assert.isTrue(e.defaultPrevented, 'should prevent default');
+          done();
+        }, 350);
+      });
 
-          buttonFocusSpy.reset();
-          drawer.opened = false;
+      test('focus trap with app-drawer tabindex set', function(done) {
+        var focusDrawer = fixture('focusDrawer');
+        var root = Polymer.dom(focusDrawer.root);
+        var drawer = root.querySelector('app-drawer');
+        var input = Polymer.dom(drawer).querySelector('input');
+        var drawerFocusSpy = sinon.spy(drawer, 'focus');
+        var inputFocusSpy = sinon.spy(input, 'focus');
+        drawer.tabIndex = 0;
+        drawer.opened = true;
 
-          window.setTimeout(function() {
-            assert.isTrue(buttonFocusSpy.called);
-            done();
-          }, 350);
+        window.setTimeout(function() {
+          assert.isTrue(drawerFocusSpy.called);
+          assert.isFalse(inputFocusSpy.called);
+          done();
         }, 350);
       });
 
       test('no focus trap', function(done) {
         var focusDrawer = fixture('focusDrawer');
         var root = Polymer.dom(focusDrawer.root);
-        var button = root.querySelector('button');
         var drawer = root.querySelector('app-drawer');
         var input = Polymer.dom(drawer).querySelector('input');
         var inputFocusSpy = sinon.spy(input, 'focus');
         drawer.noFocusTrap = true;
-        button.focus();
         drawer.opened = true;
   
         window.setTimeout(function() {


### PR DESCRIPTION
cc @frankiefu @blasten 

You can test the behavior in app-drawer/demo/demo2.html by adding `tabindex="0"` to `<app-drawer>`.